### PR TITLE
update CMake 3.8 support for CUDA 9, makes CUDA C++ an intrinsically …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(cis565_rasterizer)
+project(cis565_rasterizer LANGUAGES CXX CUDA)
+
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
@@ -48,9 +49,9 @@ set(CUDA_PROPAGATE_HOST_FLAGS OFF)
 set(CMAKE_CXX_FLAGS_DEBUG                 "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO        "-O2 -g")
 set(CMAKE_CXX_FLAGS_RELEASE               "-O3    -DNDEBUG")
-list(APPEND CUDA_NVCC_FLAGS_DEBUG          -O0 -g -G)
-list(APPEND CUDA_NVCC_FLAGS_RELWITHDEBINFO -O2 -g -lineinfo)
-list(APPEND CUDA_NVCC_FLAGS_RELEASE        -O3    -DNDEBUG)
+#list(APPEND CUDA_NVCC_FLAGS_DEBUG          -O0 -g -G)
+#list(APPEND CUDA_NVCC_FLAGS_RELWITHDEBINFO -O2 -g -lineinfo)
+#list(APPEND CUDA_NVCC_FLAGS_RELEASE        -O3    -DNDEBUG)
 if (WIN32)
     set(CUDA_PROPAGATE_HOST_FLAGS ON)
     set(CMAKE_CXX_FLAGS                       "/MD /EHsc /D _CRT_SECURE_NO_WARNINGS")
@@ -76,8 +77,8 @@ if (WIN32)
 endif()
 
 # CUDA linker options
-find_package(Threads REQUIRED)
-find_package(CUDA 8.0 REQUIRED)
+#find_package(Threads REQUIRED)
+#find_package(CUDA 8.0 REQUIRED)
 set(CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE ON)
 set(CUDA_SEPARABLE_COMPILATION ON)
 
@@ -85,10 +86,12 @@ set(CUDA_SEPARABLE_COMPILATION ON)
 add_subdirectory(src)
 add_subdirectory(util)
 
-cuda_add_executable(${CMAKE_PROJECT_NAME}
+add_executable(${CMAKE_PROJECT_NAME}
     "src/main.hpp"
     "src/main.cpp"
     )
+
+target_compile_features(${CMAKE_PROJECT_NAME} PUBLIC cxx_std_11)
 
 target_link_libraries(${CMAKE_PROJECT_NAME}
     src

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,6 @@ set(SOURCE_FILES
     "rasterizeTools.h"
     )
 
-cuda_add_library(src
+add_library(src
     ${SOURCE_FILES}
-    OPTIONS -arch=sm_20
     )

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -6,7 +6,6 @@ set(SOURCE_FILES
     "tiny_gltf_loader.h"
    )
 
-cuda_add_library(util
+add_library(util
    ${SOURCE_FILES}
-   OPTIONS -arch=sm_52
    )


### PR DESCRIPTION
…supported language

(add_executable instead of cuda_add_executable and add_library instead of cuda_add_library)
see https://devblogs.nvidia.com/parallelforall/building-cuda-applications-cmake/

Noticed this project through twitter, here: https://twitter.com/pjcozzi/status/932394589956247553,
tried compiling it with Visual Studio 2017, CUDA 9, it failed. This patch makes it work (at least for me).

Project well done, rendering looks great!